### PR TITLE
Fixes and extra features added over the years

### DIFF
--- a/wsdl2php.xsl
+++ b/wsdl2php.xsl
@@ -6,9 +6,11 @@
     xmlns:php="http://php.net/xsl"
     xmlns:exslt="http://exslt.org/common">
 
+<!-- Entry point template -->
 <xsl:template match="/*[local-name()='definitions' and namespace-uri()='http://schemas.xmlsoap.org/wsdl/']">
     <wsdl2php>
         <services>
+            <!-- select all service tags -->
             <xsl:for-each select="*[local-name()='service' and namespace-uri()='http://schemas.xmlsoap.org/wsdl/']">
                 <service name="{@name}">
                     <functions>
@@ -68,13 +70,16 @@
             </xsl:for-each>
         </services>
         <classes>
+            <!-- select all types/complexType or types/simpleType nodes unless the tag name starts with ArrayOf -->
             <xsl:for-each select="*[local-name()='types' and namespace-uri()='http://schemas.xmlsoap.org/wsdl/']
                     //*[(local-name()='complexType' or local-name()='simpleType') and 
                         not(starts-with(@name, 'ArrayOf'))]">
                 <class name="{@name | ../@name}">
+                    <!-- check if any descendant node has the tag name 'extension' -->
                     <xsl:if test=".//*[local-name()='extension']">
                         <extends>
                             <xsl:choose>
+                                <!-- and get the value of the base attribute (strip namespace) -->
                                 <xsl:when test="contains(.//*[local-name()='extension']/@base,':')">
                                     <xsl:value-of select="substring-after(.//*[local-name()='extension']/@base,':')" />
                                 </xsl:when>
@@ -84,9 +89,12 @@
                             </xsl:choose>
                         </extends>
                     </xsl:if>
-                    <xsl:if test=".//*[local-name()='element']">
+                    <!-- are there any descendant element or attribute tags? -->
+                    <xsl:if test=".//*[local-name()='element'] or .//*[local-name()='attribute']">
+                        <!-- yes, so lets create properties from element or attribute tags -->
                         <properties>
                             <xsl:apply-templates select=".//*[local-name()='element']" />
+                            <xsl:apply-templates select=".//*[local-name()='attribute']" />
                         </properties>
                     </xsl:if>
                 </class>
@@ -95,6 +103,12 @@
     </wsdl2php>
 </xsl:template>
 
+<!-- 
+  handle message tags 
+  
+  This is called from the 'services'.
+  Basically this will generate the method definitions
+-->
 <xsl:template match="*[local-name()='message' and namespace-uri()='http://schemas.xmlsoap.org/wsdl/']">
     <xsl:for-each select="*[local-name()='part' and namespace-uri()='http://schemas.xmlsoap.org/wsdl/']">
         <xsl:choose>
@@ -122,6 +136,12 @@
     </xsl:for-each>
 </xsl:template>
 
+<!-- 
+  handle element tags (in types)
+  
+  Unfortunately this template does not know the context of an element, it
+  matches elements in local complexType definitions, but i don't know how to prevent this
+-->
 <xsl:template match="*[local-name()='element' and namespace-uri()='http://www.w3.org/2001/XMLSchema']">
     <xsl:choose>
         <xsl:when test="@ref and @name">
@@ -161,31 +181,95 @@
     </xsl:choose>
 </xsl:template>
 
+<!-- 
+  handle attribute tags (in types)
+  
+  Unfortunately this template does not know the context of an attribute
+-->
+<xsl:template match="*[local-name()='attribute' and namespace-uri()='http://www.w3.org/2001/XMLSchema']">
+    <xsl:choose>
+        <xsl:when test="@type and @name">
+            <xsl:call-template name="messagePart">
+                <xsl:with-param name="refnode" select="current()" />
+                <xsl:with-param name="name" select="@name" />
+                <xsl:with-param name="type" select="@type" />
+            </xsl:call-template>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:call-template name="messagePart">
+                <xsl:with-param name="refnode" select="current()" />
+                <xsl:with-param name="name" select="@name" />
+            </xsl:call-template>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- handles types (add entry name="" type="" tags, used in buth function/parameter and class/properties declarations) -->
 <xsl:template name="messagePart">
     <xsl:param name="refnode" />
     <xsl:param name="name" />
     <xsl:param name="type" />
+    <xsl:variable name="arraytype">
+      <xsl:choose>
+          <xsl:when test="$refnode[@maxOccurs='unbounded']">[]</xsl:when>
+          <xsl:otherwise></xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
     <xsl:choose>
+        <!-- no type specified -->
+        <!-- type is optional, so this is valid, should be handled as direct type declaration? -->
         <xsl:when test="string-length($type)=0">
+            <!-- do we have a nested complextype? -->
             <xsl:choose>
-                <xsl:when test="$refnode[@maxOccurs='unbounded']">
-                    <entry debug="1" name="{$name}" type="anyType[]" error="no type or element in message" />
+                <!-- is there exactly one element in the complexType? -->
+                <xsl:when test="count($refnode
+                                /*[local-name()='complexType' and namespace-uri()='http://www.w3.org/2001/XMLSchema']
+                                /*[local-name()='sequence' and namespace-uri()='http://www.w3.org/2001/XMLSchema']
+                                /*[local-name()='element' and namespace-uri()='http://www.w3.org/2001/XMLSchema' and (@type or @ref) ] )=1">
+                    <xsl:variable name="matchedNode" select="$refnode
+                                /*[local-name()='complexType' and namespace-uri()='http://www.w3.org/2001/XMLSchema']
+                                /*[local-name()='sequence' and namespace-uri()='http://www.w3.org/2001/XMLSchema']
+                                /*[local-name()='element' and namespace-uri()='http://www.w3.org/2001/XMLSchema'][1]" />
+                    <xsl:variable name="subArraytype">
+                      <xsl:choose>
+                          <xsl:when test="$refnode[@maxOccurs='unbounded']">[]</xsl:when>
+                          <xsl:when test="$matchedNode[@maxOccurs='unbounded']">[]</xsl:when>
+                          <xsl:otherwise></xsl:otherwise>
+                      </xsl:choose>
+                    </xsl:variable>
+                    <xsl:call-template name="writeEntry">
+                        <xsl:with-param name="debug">1b</xsl:with-param>
+                        <xsl:with-param name="name"><xsl:value-of select="$name"/></xsl:with-param>
+                        <xsl:with-param name="type"><xsl:choose>
+                                <xsl:when test="$matchedNode[@type] and contains($matchedNode/@type,':')"><xsl:value-of select="substring-after($matchedNode/@type,':')"/></xsl:when>
+                                <xsl:when test="$matchedNode[@type]"><xsl:value-of select="$matchedNode/@type"/></xsl:when>
+                                <xsl:when test="$matchedNode[@ref] and contains($matchedNode/@ref,':')"><xsl:value-of select="substring-after($matchedNode/@ref,':')"/></xsl:when>
+                                <xsl:when test="$matchedNode[@ref]"><xsl:value-of select="$matchedNode/@ref"/></xsl:when>
+                            </xsl:choose><xsl:value-of select="$subArraytype"/></xsl:with-param>
+                    </xsl:call-template>
                 </xsl:when>
+                <!-- currently we cannot handle unnamed complex types which are actually complex (more than one element) 
+                     It would require a new type/class definition with a made up name, but we couldn't handle those anyway
+                -->
                 <xsl:otherwise>
-                    <entry debug="1" name="{$name}" type="anyType" error="no type or element in message" />
+                    <xsl:call-template name="writeEntry">
+                        <xsl:with-param name="debug">1</xsl:with-param>
+                        <xsl:with-param name="name"><xsl:value-of select="$name"/></xsl:with-param>
+                        <xsl:with-param name="type">anyType<xsl:value-of select="$arraytype"/></xsl:with-param>
+                        <xsl:with-param name="error">no type or element in message</xsl:with-param>
+                    </xsl:call-template>
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:when>
+        <!-- base xsd types -->
         <xsl:when test="(substring-before($type,':')='xsd') or (substring-before($type,':')='xs')">
-            <xsl:choose>
-                <xsl:when test="$refnode[@maxOccurs='unbounded']">
-                    <entry debug="2" name="{$name}" type="{substring-after($type,':')}[]" />
-                </xsl:when>
-                <xsl:otherwise>
-                    <entry debug="2" name="{$name}" type="{substring-after($type,':')}" />
-                </xsl:otherwise>
-            </xsl:choose>
+          <xsl:call-template name="writeEntry">
+              <xsl:with-param name="debug">2</xsl:with-param>
+              <xsl:with-param name="name"><xsl:value-of select="$name"/></xsl:with-param>
+              <xsl:with-param name="type"><xsl:value-of select="substring-after($type,':')"/><xsl:value-of select="$arraytype"/></xsl:with-param>
+          </xsl:call-template>
         </xsl:when>
+        <!-- check if there is a element tag directly in schema whose name matches the $type (ignoring namespace) -->
         <xsl:when test="//*[local-name()='schema' and namespace-uri()='http://www.w3.org/2001/XMLSchema']
                         /*[local-name()='element' and namespace-uri()='http://www.w3.org/2001/XMLSchema' 
                         and (@name=substring-after($type,':') or @name=$type)]">
@@ -193,52 +277,46 @@
                         /*[local-name()='element' and namespace-uri()='http://www.w3.org/2001/XMLSchema' 
                         and (@name=substring-after($type,':') or @name=$type)]" />
             <xsl:choose>
+                <!-- does the element have a type attribute? -->
                 <xsl:when test="$matchedNode/@type">
                     <xsl:choose>
+                        <!-- does the type attribute have a namespace? -->
                         <xsl:when test="contains($matchedNode/@type,':')">
-                            <xsl:choose>
-                                <xsl:when test="$refnode[@maxOccurs='unbounded']">
-                                    <entry debug="3" name="{$name}" type="{substring-after($matchedNode/@type,':')}[]" />
-                                </xsl:when>
-                                <xsl:otherwise>
-                                    <entry debug="3" name="{$name}" type="{substring-after($matchedNode/@type,':')}" />
-                                </xsl:otherwise>
-                            </xsl:choose>                        
+                          <xsl:call-template name="writeEntry">
+                              <xsl:with-param name="debug">3</xsl:with-param>
+                              <xsl:with-param name="name"><xsl:value-of select="$name"/></xsl:with-param>
+                              <xsl:with-param name="type"><xsl:value-of select="substring-after($matchedNode/@type,':')"/><xsl:value-of select="$arraytype"/></xsl:with-param>
+                          </xsl:call-template>
                         </xsl:when>
                         <xsl:otherwise>
-                            <xsl:choose>
-                                <xsl:when test="$refnode[@maxOccurs='unbounded']">
-                                    <entry debug="3b" name="{$name}" type="{$matchedNode/@type}[]" />
-                                </xsl:when>
-                                <xsl:otherwise>
-                                    <entry debug="3b" name="{$name}" type="{$matchedNode/@type}" />
-                                </xsl:otherwise>
-                            </xsl:choose>                           
+                          <xsl:call-template name="writeEntry">
+                              <xsl:with-param name="debug">3b</xsl:with-param>
+                              <xsl:with-param name="name"><xsl:value-of select="$name"/></xsl:with-param>
+                              <xsl:with-param name="type"><xsl:value-of select="$matchedNode/@type"/><xsl:value-of select="$arraytype"/></xsl:with-param>
+                          </xsl:call-template>
                         </xsl:otherwise>
                     </xsl:choose>
                 </xsl:when>
+                <!-- or else does the element have a name attribute? -->
                 <xsl:when test="$matchedNode/@name">
-                    <xsl:choose>
-                        <xsl:when test="$refnode[@maxOccurs='unbounded']">
-                            <entry debug="3c" name="{$name}" type="{$matchedNode/@name}[]" />
-                        </xsl:when>
-                        <xsl:otherwise>
-                            <entry debug="3c" name="{$name}" type="{$matchedNode/@name}" />
-                        </xsl:otherwise>
-                    </xsl:choose>                    
+                    <xsl:call-template name="writeEntry">
+                        <xsl:with-param name="debug">3c</xsl:with-param>
+                        <xsl:with-param name="name"><xsl:value-of select="$name"/></xsl:with-param>
+                        <xsl:with-param name="type"><xsl:value-of select="$matchedNode/@name"/><xsl:value-of select="$arraytype"/></xsl:with-param>
+                    </xsl:call-template>
                 </xsl:when>
+                <!-- or else (no name or type attribute, bad situation) -->
                 <xsl:otherwise>
-                    <xsl:choose>
-                        <xsl:when test="$refnode[@maxOccurs='unbounded']">
-                            <entry debug="3d" name="{$name}" type="{$name}[]" error="bad element type def" />
-                        </xsl:when>
-                        <xsl:otherwise>
-                            <entry debug="3d" name="{$name}" type="{$name}" error="bad element type def" />
-                        </xsl:otherwise>
-                    </xsl:choose>                      
+                    <xsl:call-template name="writeEntry">
+                        <xsl:with-param name="debug">3d</xsl:with-param>
+                        <xsl:with-param name="name"><xsl:value-of select="$name"/></xsl:with-param>
+                        <xsl:with-param name="type"><xsl:value-of select="$name"/><xsl:value-of select="$arraytype"/></xsl:with-param>
+                        <xsl:with-param name="error">bad element type def</xsl:with-param>
+                    </xsl:call-template>
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:when>
+        <!-- check if there is a complexType tag directly in schema whose name matches the $type (ignoring namespace) and who has descendants with the ref='soapenc:arrayType' attribute -->
         <xsl:when test="//*[local-name()='schema' and namespace-uri()='http://www.w3.org/2001/XMLSchema']
                         /*[local-name()='complexType' and namespace-uri()='http://www.w3.org/2001/XMLSchema' 
                         and (@name=substring-after($type,':') or @name=$type)]//*[@ref='soapenc:arrayType']">
@@ -249,13 +327,22 @@
                         /@*[local-name()='arrayType']" />
             <xsl:choose>
                 <xsl:when test="contains($typeref,':')">
-                    <entry debug="4" name="{$name}" type="{substring-after($typeref,':')}" />
+                    <xsl:call-template name="writeEntry">
+                        <xsl:with-param name="debug">4</xsl:with-param>
+                        <xsl:with-param name="name"><xsl:value-of select="$name"/></xsl:with-param>
+                        <xsl:with-param name="type"><xsl:value-of select="substring-after($typeref,':')"/></xsl:with-param>
+                    </xsl:call-template>
                 </xsl:when>
                 <xsl:otherwise>
-                    <entry debug="4b" name="{$name}" type="{$typeref}" />
+                    <xsl:call-template name="writeEntry">
+                        <xsl:with-param name="debug">4b</xsl:with-param>
+                        <xsl:with-param name="name"><xsl:value-of select="$name"/></xsl:with-param>
+                        <xsl:with-param name="type"><xsl:value-of select="$typeref"/></xsl:with-param>
+                    </xsl:call-template>
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:when>
+        <!-- check if there is a complexType tag directly in schema whose name matches the $type (must have namespace) -->
         <xsl:when test="//*[local-name()='schema' and namespace-uri()='http://www.w3.org/2001/XMLSchema']
                         /*[local-name()='complexType' and namespace-uri()='http://www.w3.org/2001/XMLSchema' 
                         and @name=substring-after($type,':')]">
@@ -265,38 +352,63 @@
                         and (@name=substring-after($type,':') or @name=$type)]/@name" />
             <xsl:choose>
                 <xsl:when test="contains($typeref,':')">
-                    <xsl:choose>
-                        <xsl:when test="$refnode[@maxOccurs='unbounded']">
-                            <entry debug="5" name="{$name}" type="{substring-after($typeref,':')}[]" />
-                        </xsl:when>
-                        <xsl:otherwise>
-                            <entry debug="5" name="{$name}" type="{substring-after($typeref,':')}" />
-                        </xsl:otherwise>
-                    </xsl:choose>
+                    <xsl:call-template name="writeEntry">
+                        <xsl:with-param name="debug">5</xsl:with-param>
+                        <xsl:with-param name="name"><xsl:value-of select="$name"/></xsl:with-param>
+                        <xsl:with-param name="type"><xsl:value-of select="substring-after($typeref,':')"/><xsl:value-of select="$arraytype"/></xsl:with-param>
+                    </xsl:call-template>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:choose>
-                        <xsl:when test="$refnode[@maxOccurs='unbounded']">
-                            <entry debug="5b" name="{$name}" type="{$typeref}[]" />
-                        </xsl:when>
-                        <xsl:otherwise>
-                            <entry debug="5b" name="{$name}" type="{$typeref}" />
-                        </xsl:otherwise>
-                    </xsl:choose>                
+                    <xsl:call-template name="writeEntry">
+                        <xsl:with-param name="debug">5b</xsl:with-param>
+                        <xsl:with-param name="name"><xsl:value-of select="$name"/></xsl:with-param>
+                        <xsl:with-param name="type"><xsl:value-of select="$typeref"/><xsl:value-of select="$arraytype"/></xsl:with-param>
+                    </xsl:call-template>
                 </xsl:otherwise>
             </xsl:choose>                        
         </xsl:when>
+        <!-- if none of the above matches -->
         <xsl:otherwise>
-            <xsl:choose>
-                <xsl:when test="$refnode[@maxOccurs='unbounded']">
-                    <entry debug="6" name="{$name}" type="{$type}[]" error="uninterpreted" fname="{name($refnode)}" lname="{local-name($refnode)}" uri="{namespace-uri($refnode)}" />
-                </xsl:when>
-                <xsl:otherwise>
-                    <entry debug="6" name="{$name}" type="{$type}" error="uninterpreted" fname="{name($refnode)}" lname="{local-name($refnode)}" uri="{namespace-uri($refnode)}" />
-                </xsl:otherwise>
-            </xsl:choose>            
+            <xsl:call-template name="writeEntry">
+                <xsl:with-param name="debug">6</xsl:with-param>
+                <xsl:with-param name="name"><xsl:value-of select="$name"/></xsl:with-param>
+                <xsl:with-param name="type"><xsl:value-of select="$type"/><xsl:value-of select="$arraytype"/></xsl:with-param>
+                <xsl:with-param name="error">uninterpreted</xsl:with-param>
+                <xsl:with-param name="fname"><xsl:value-of select="name($refnode)"/></xsl:with-param>
+                <xsl:with-param name="lname"><xsl:value-of select="local-name($refnode)"/></xsl:with-param>
+                <xsl:with-param name="uri"><xsl:value-of select="namespace-uri($refnode)"/></xsl:with-param>
+            </xsl:call-template>
         </xsl:otherwise>
     </xsl:choose>
+</xsl:template>
+
+<!-- write the entry tag -->
+<xsl:template name="writeEntry">
+    <xsl:param name="debug" />
+    <xsl:param name="name" />
+    <xsl:param name="type" />
+    <!-- optional attributes -->
+    <xsl:param name="error" />
+    <xsl:param name="fname" />
+    <xsl:param name="lname" />
+    <xsl:param name="uri" />
+    <xsl:element name="entry">
+      <xsl:attribute name="debug"><xsl:value-of select="$debug"/></xsl:attribute>
+      <xsl:attribute name="name"><xsl:value-of select="$name"/></xsl:attribute>
+      <xsl:attribute name="type"><xsl:value-of select="$type"/></xsl:attribute>
+      <xsl:if test="string-length($error) &gt; 0">
+         <xsl:attribute name="error"><xsl:value-of select="$error"/></xsl:attribute>
+      </xsl:if>
+      <xsl:if test="string-length($fname) &gt; 0">
+         <xsl:attribute name="fname"><xsl:value-of select="$fname"/></xsl:attribute>
+      </xsl:if>
+      <xsl:if test="string-length($lname) &gt; 0">
+         <xsl:attribute name="lname"><xsl:value-of select="$lname"/></xsl:attribute>
+      </xsl:if>
+      <xsl:if test="string-length($uri) &gt; 0">
+         <xsl:attribute name="uri"><xsl:value-of select="$uri"/></xsl:attribute>
+      </xsl:if>
+    </xsl:element>
 </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
I have just created a pull request with all the changes we made to the WSDLInterpreter over the years. Feel free to merge them in (or not) or cherry-pick. Below are the changes contained in this PR.

Improve generic usage of interpreter
- WSDLInterpreter:
  -- added logging option (_debugLog() method) enable with
      setLogging(true)
  -- changed params of parseWSDL; this breaks backwards compatibility,
      but we added output directory so we can write intermediate files
      somewhere
  -- parseWSDL: added logging statements and moved parsing of wsdl
      with SoapClient more to the end, we test it on our intermediate
      file instead of the source wsdl file. Intermediate xml files are
      written to output directory for debugging.

Improve handling of wsdl, now handles nested complexType's with only
one element
- wsdl2php.xsl: now handles one more (very specific) situation: when
  an element contains a complexType with a sequence with exactly one
  element which has a type or ref attribute. In these situations the
  type will be collapsed into the type of the parent element. These
  constructs are used alot for array declarations in the cisco MSE.

Improve handling of wsdl, now handles attributes too
- wsdl2php.xsl:
  -- added a new xsl:template for matching attribute elements and
      handle them with the messagePart template
  -- added a new named xsl:template writeEntry for outputting entry
      tags. it accepts several params and uses them to create
      attributes.
  -- refactored messagePart template so it writes the entry tag with
      new writeEntry template
  -- changed the main matching template to apply template matching on
      'attribute elements', just like the 'element' elements.

Improve handling of wsdl
- wsdl2php.xsl: added comments to better understand how this xslt
  works (so we can improve it later)

Added properties to restore backwards compatible behavior
- WSDLInterpreter: The class no longer does all the parsing in the
  constructor. This is bad practice and you cannot set properties to
  influence parsing behavior. Now there is a separate parseWSDL()
  method which gets called automatically from the savePHP() method if
  the wsdl was not yet parsed. Also added setAddClassExistCheck() and
  setOneBigFile() methods. If you set both then you get the similar
  output as the first WSDLInterpreter version.

Bugfix https://github.com/JBlond/WSDLInterpreter/commit/a4a33497710202d6
f9b7f54175e7bcc91e05eec8 but implemented differently
- WSDLInterpreter: initialize $sources array and do not use sizeof (as
  it is only an alias for count)

Made namespaces optional
- WSDLInterpreter: it added an hardcoded namespace, now add a
  configurable namespace and default to no namespace at all. Use the
  new setPHPNamespace() method for this.